### PR TITLE
Toolchain update - rust stable 1.85

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.84.0
+      - uses: dtolnay/rust-toolchain@1.85.0
         with:
           toolchain: stable
           targets: wasm32-wasip1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,10 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-wasip1
-          components: rustfmt
+          components: rustfmt,clippy
       - name: Format
-        run: |
-          cargo -V
-          cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-features --all-targets -- -D warnings
       - name: Check
-        run: |
-          cargo -V
-          cargo check --release --all --all-features
+        run: cargo check --release --all --all-features

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.84.0
+      - uses: dtolnay/rust-toolchain@1.85.0
         with:
           toolchain: stable
           targets: wasm32-wasip1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-wasip1"]
 profile = "default"


### PR DESCRIPTION
This pull request updates the Rust toolchain version and enhances the CI workflows by adding Clippy for linting. The most important changes include upgrading the Rust version to 1.85.0, adding the Clippy component, and modifying the CI workflows to include a Clippy linting step.

### Rust toolchain updates:
* Updated the Rust version from `1.84.0` to `1.85.0` in `.github/workflows/ci.yaml`, `.github/workflows/publish.yaml`, and `rust-toolchain.toml`. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL14-R24) [[2]](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL17-R17) [[3]](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL2-R2)
* Added the `clippy` component alongside `rustfmt` in the Rust toolchain configuration in `rust-toolchain.toml`.

### CI workflow enhancements:
* Updated the CI workflow in `.github/workflows/ci.yaml` to include a new step for running Clippy (`cargo clippy`) with all features and targets, and configured it to fail on warnings.
* Simplified the `cargo fmt` and `cargo check` steps in `.github/workflows/ci.yaml` by removing redundant commands.