### PR TITLE
docs: quick fix for build instructions typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 1. Install the rust with rustup, please visit the site 'https://rustup.rs/'.
 
-2. Use follow command for build the project.
+2. Use the following command to build the project.
 
 ```bash
 $ cargo build


### PR DESCRIPTION
just cleaned up a small typo in the build steps.
changed "Use follow command for build the project." to "Use the following command to build the project."

hope this makes it clearer!
